### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/webpackts/security/code-scanning/1](https://github.com/Adam-Robson/webpackts/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and does not perform any write operations. Therefore, the `contents: read` permission is sufficient.

The `permissions` block should be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
